### PR TITLE
SC-19129 allow subpath exports for keplr packages

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -87,11 +87,11 @@ module.exports = {
     'no-restricted-globals': ['error', 'isFinite', 'isNaN'],
     'no-restricted-imports': [
       'error',
-      { patterns: ['lodash/*', '@keplr/*/*'] },
+      { patterns: ['lodash/*', '@keplr/*/*/*'] },
     ],
     'no-restricted-modules': [
       'error',
-      { patterns: ['lodash/*', '@keplr/*/*'] },
+      { patterns: ['lodash/*', '@keplr/*/*/*'] },
     ],
     'no-restricted-properties': [
       'error',

--- a/lib/index.js
+++ b/lib/index.js
@@ -85,14 +85,8 @@ module.exports = {
     'no-promise-executor-return': 'error',
     'no-proto': 'error',
     'no-restricted-globals': ['error', 'isFinite', 'isNaN'],
-    'no-restricted-imports': [
-      'error',
-      { patterns: ['@keplr/*/*/*'] },
-    ],
-    'no-restricted-modules': [
-      'error',
-      { patterns: ['@keplr/*/*/*'] },
-    ],
+    'no-restricted-imports': ['error', { patterns: ['@keplr/*/*/*'] }],
+    'no-restricted-modules': ['error', { patterns: ['@keplr/*/*/*'] }],
     'no-restricted-properties': [
       'error',
       {

--- a/lib/index.js
+++ b/lib/index.js
@@ -87,11 +87,11 @@ module.exports = {
     'no-restricted-globals': ['error', 'isFinite', 'isNaN'],
     'no-restricted-imports': [
       'error',
-      { patterns: ['lodash/*', '@keplr/*/*/*'] },
+      { patterns: ['@keplr/*/*/*'] },
     ],
     'no-restricted-modules': [
       'error',
-      { patterns: ['lodash/*', '@keplr/*/*/*'] },
+      { patterns: ['@keplr/*/*/*'] },
     ],
     'no-restricted-properties': [
       'error',


### PR DESCRIPTION
### Info sur la story
### Summary : 
Allow one-level subpath exports (e.g. `import { sanitize } from '@keplr/api-common/security'`) by relaxing the lint pattern from `@keplr/*/*` to `@keplr/*/*/*`, keeping deep internal imports restricted.

Linked with the PR : https://github.com/keplr-team/api-common/pull/94
### Jira : 
https://keplr.atlassian.net/browse/SC-19129